### PR TITLE
moved references below our team section, added personal links

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,8 @@
         <p>RedPoint is a free and open-source computational notebook tool that emphasizes ease of use, multi-language
           support and web connectivity. RedPoint notebooks run in the browser, and allow you to write and execute
           JavaScript, Ruby, and Python code within the same document. This case study will explain the uses of
-          notebooks in general, detail the design goals and features of RedPoint, and highlight our solutions to the many
+          notebooks in general, detail the design goals and features of RedPoint, and highlight our solutions to the
+          many
 
           technical challenges involved in building a web-native computational notebook.
           <hr />
@@ -1262,7 +1263,7 @@
       </div>
 
       <div class="chapter">
-        <h2 id="future-work">7 Future Work</h2>
+        <h2 id="future-work">6 Future Work</h2>
         <ul>
           <li>Implement optional user authentication in order to more easily organize notebooks</li>
           <li>
@@ -1272,104 +1273,6 @@
           <li>Augment our existing testing suite</li>
         </ul>
       </div>
-
-      <section id="footnotes">
-        <h2 id="references">8 References</h2>
-        <h4>8.1 Computational Notebooks</h4>
-        <ul>
-          <li>
-            <a href="https://towardsdatascience.com/jupyter-lab-evolution-of-the-jupyter-notebook-5297cacde6b"
-              target="_blank">Jupyter Lab: Evolution of the Jupyter Notebook</a>
-          </li>
-          <li>
-            <a href="https://blog.nteract.io/nteract-building-on-top-of-jupyter-9cfbccdd4c1d" target="_blank">nteract:
-              Building on Top of Jupyter</a>
-          </li>
-          <li>
-            <a href="https://moderndata.plot.ly/nteract-revolutionizing-notebook-experience/" target="_blank">nteract:
-              Revolutionizing the Notebook Experience</a>
-          </li>
-          <li>
-            <a href="https://www.theatlantic.com/science/archive/2018/04/the-scientific-paper-is-obsolete/556676/"
-              target="_blank">The Scientific Paper is Obsolete</a>
-          </li>
-          <li>
-            <a href="https://medium.com/netflix-techblog/notebook-innovation-591ee3221233" target="_blank">Notebook
-              Innovation at Netflix</a>
-          </li>
-          <li>
-            <a href="https://hackernoon.com/simplify-devops-with-jupyter-notebook-c700fb6b503c" target="_blank">Devops
-              with Juypter</a>
-          </li>
-          <li>
-            <a href="https://docs.google.com/presentation/d/1n2RlMdmv1p25Xy5thJUhkKGvjtV-dkAIsUXP-AL4ffI/edit#slide=id.g37ce315c78_0_27"
-              target="_blank">I Don't Like Notebooks</a>
-          </li>
-          <li>
-            <a href="https://yihui.name/en/2018/09/notebook-war/" target="_blank">Notebook Wars</a>
-          </li>
-          <li>
-            <a href="https://blog.runkit.com/2015/09/10/time-traveling-in-node-js-notebooks/" target="_blank">Time
-              Traveling in Node.js Notebooks</a>
-          </li>
-          <li>
-            <a href="https://medium.com/netflix-techblog/open-sourcing-polynote-an-ide-inspired-polyglot-notebook-7f929d3f447"
-              target="_blank">Open-Sourcing Polynote</a>
-          </li>
-          <li>
-            <a href="https://observablehq.com/@observablehq/observables-not-javascript%3E" target="_blank">Observable's
-              Not Javascript</a>
-          </li>
-        </ul>
-        <h4>8.2 WebSockets</h4>
-        <ul>
-          <li>
-            <a href="https://www.ably.io/concepts/websockets" target="_blank">WebSockets - A Conceptual Deep-Dive</a>
-          </li>
-          <li>
-            <a href="http://www.diva-portal.se/smash/get/diva2:1133465/FULLTEXT01.pdf" target="_blank">Performance
-              comparison of XHR polling, Long polling, Server sent events and Websockets</a>
-          </li>
-          <li>
-            <a href="https://blog.feathersjs.com/http-vs-websockets-a-performance-comparison-da2533f13a77"
-              target="_blank">HTTP vs Websockets: A performance comparison</a>
-          </li>
-        </ul>
-        <h4>8.3 Node Child Processes and Streams</h4>
-        <ul>
-          <li>
-            <a href="https://dzone.com/articles/understanding-execfile-spawn-exec-and-fork-in-node"
-              target="_blank">execFile, spawn, exec, and fork in Node.js</a>
-          </li>
-          <li>
-            <a href="https://www.freecodecamp.org/news/node-js-streams-everything-you-need-to-know-c9141306be93/"
-              target="_blank">Node JS Streams</a>
-          </li>
-        </ul>
-        <h4>8.4 Permissions, gVisor, and cgroups</h4>
-
-        <ul>
-          <li>
-            <a href="https://www.ostechnix.com/how-to-limit-users-access-to-the-linux-system/" target="_blank">Limit
-              User's Access To The Linux System</a>
-          </li>
-          <li>
-            <a href="https://gvisor.dev/docs/" target="_blank">gVisor Security Model</a>
-          </li>
-          <li>
-            <a href="https://thenewstack.io/how-to-implement-secure-containers-using-googles-gvisor/"
-              target="_blank">Implement Secure Containers Using Google's gVisor</a>
-          </li>
-          <li>
-            <a href="https://docs.docker.com/config/containers/resource_constraints/" target="_blank">Runtime Options
-              With Memory, CPUs, and GPUs</a>
-          </li>
-          <li>
-            <a href="https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b"
-              target="_blank">Container Processes Shouldn't Run as Root</a>
-          </li>
-        </ul>
-      </section>
     </section>
   </main>
 
@@ -1377,7 +1280,7 @@
     <h1>Our Team</h1>
 
     <p>
-      We are all looking forward to new opportunities. Please contact us if this project interested you, or if you have
+      We are looking forward to new opportunities. Please contact us if this project interested you, or if you have
       any questions!
     </p>
 
@@ -1419,7 +1322,7 @@
 
         <ul class="social-icons">
           <li>
-            <a href="mailto:" target="">
+            <a href="mailto:benjaminriderharvey@gmail.com" target="">
               <img src="images/icons/email_icon.png" alt="email" />
             </a>
           </li>
@@ -1431,7 +1334,7 @@
           </li>
 
           <li>
-            <a href="" target="_blank">
+            <a href="https://www.linkedin.com/in/ben-harvey-767304178/" target="_blank">
               <img src="images/icons/linked_in_icon.png" alt="linkedin" />
             </a>
           </li>
@@ -1447,7 +1350,7 @@
 
         <ul class="social-icons">
           <li>
-            <a href="mailto:" target="">
+            <a href="mailto:millswilliamrobert@gmail.com" target="">
               <img src="images/icons/email_icon.png" alt="email" />
             </a>
           </li>
@@ -1459,11 +1362,109 @@
           </li>
 
           <li>
-            <a href="" target="_blank">
+            <a href="https://www.linkedin.com/in/w-mills" target="_blank">
               <img src="images/icons/linked_in_icon.png" alt="linkedin" />
             </a>
           </li>
         </ul>
+      </li>
+    </ul>
+  </section>
+
+  <section id="footnotes">
+    <h2 id="references">7 References</h2>
+    <h4 id="ref-heading">7.1 Computational Notebooks</h4>
+    <ul>
+      <li>
+        <a href="https://towardsdatascience.com/jupyter-lab-evolution-of-the-jupyter-notebook-5297cacde6b"
+          target="_blank">Jupyter Lab: Evolution of the Jupyter Notebook</a>
+      </li>
+      <li>
+        <a href="https://blog.nteract.io/nteract-building-on-top-of-jupyter-9cfbccdd4c1d" target="_blank">nteract:
+          Building on Top of Jupyter</a>
+      </li>
+      <li>
+        <a href="https://moderndata.plot.ly/nteract-revolutionizing-notebook-experience/" target="_blank">nteract:
+          Revolutionizing the Notebook Experience</a>
+      </li>
+      <li>
+        <a href="https://www.theatlantic.com/science/archive/2018/04/the-scientific-paper-is-obsolete/556676/"
+          target="_blank">The Scientific Paper is Obsolete</a>
+      </li>
+      <li>
+        <a href="https://medium.com/netflix-techblog/notebook-innovation-591ee3221233" target="_blank">Notebook
+          Innovation at Netflix</a>
+      </li>
+      <li>
+        <a href="https://hackernoon.com/simplify-devops-with-jupyter-notebook-c700fb6b503c" target="_blank">Devops
+          with Juypter</a>
+      </li>
+      <li>
+        <a href="https://docs.google.com/presentation/d/1n2RlMdmv1p25Xy5thJUhkKGvjtV-dkAIsUXP-AL4ffI/edit#slide=id.g37ce315c78_0_27"
+          target="_blank">I Don't Like Notebooks</a>
+      </li>
+      <li>
+        <a href="https://yihui.name/en/2018/09/notebook-war/" target="_blank">Notebook Wars</a>
+      </li>
+      <li>
+        <a href="https://blog.runkit.com/2015/09/10/time-traveling-in-node-js-notebooks/" target="_blank">Time
+          Traveling in Node.js Notebooks</a>
+      </li>
+      <li>
+        <a href="https://medium.com/netflix-techblog/open-sourcing-polynote-an-ide-inspired-polyglot-notebook-7f929d3f447"
+          target="_blank">Open-Sourcing Polynote</a>
+      </li>
+      <li>
+        <a href="https://observablehq.com/@observablehq/observables-not-javascript%3E" target="_blank">Observable's
+          Not Javascript</a>
+      </li>
+    </ul>
+    <h4>7.2 WebSockets</h4>
+    <ul>
+      <li>
+        <a href="https://www.ably.io/concepts/websockets" target="_blank">WebSockets - A Conceptual Deep-Dive</a>
+      </li>
+      <li>
+        <a href="http://www.diva-portal.se/smash/get/diva2:1133465/FULLTEXT01.pdf" target="_blank">Performance
+          comparison of XHR polling, Long polling, Server sent events and Websockets</a>
+      </li>
+      <li>
+        <a href="https://blog.feathersjs.com/http-vs-websockets-a-performance-comparison-da2533f13a77"
+          target="_blank">HTTP vs Websockets: A performance comparison</a>
+      </li>
+    </ul>
+    <h4>7.3 Node Child Processes and Streams</h4>
+    <ul>
+      <li>
+        <a href="https://dzone.com/articles/understanding-execfile-spawn-exec-and-fork-in-node"
+          target="_blank">execFile, spawn, exec, and fork in Node.js</a>
+      </li>
+      <li>
+        <a href="https://www.freecodecamp.org/news/node-js-streams-everything-you-need-to-know-c9141306be93/"
+          target="_blank">Node JS Streams</a>
+      </li>
+    </ul>
+    <h4>7.4 Permissions, gVisor, and cgroups</h4>
+
+    <ul>
+      <li>
+        <a href="https://www.ostechnix.com/how-to-limit-users-access-to-the-linux-system/" target="_blank">Limit
+          User's Access To The Linux System</a>
+      </li>
+      <li>
+        <a href="https://gvisor.dev/docs/" target="_blank">gVisor Security Model</a>
+      </li>
+      <li>
+        <a href="https://thenewstack.io/how-to-implement-secure-containers-using-googles-gvisor/"
+          target="_blank">Implement Secure Containers Using Google's gVisor</a>
+      </li>
+      <li>
+        <a href="https://docs.docker.com/config/containers/resource_constraints/" target="_blank">Runtime Options
+          With Memory, CPUs, and GPUs</a>
+      </li>
+      <li>
+        <a href="https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b"
+          target="_blank">Container Processes Shouldn't Run as Root</a>
       </li>
     </ul>
   </section>

--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -138,8 +138,6 @@ document.addEventListener("DOMContentLoaded", () => {
     // .filter(logo => !/redpoint/.test(logo.id))
     .map(logo => logo.id.split("-")[0]);
 
-  console.log(logos);
-
   const snakeCaseify = text =>
     text
       .toLowerCase()

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -45,7 +45,6 @@ h3,
 h4,
 h5 {
   font-family: "Roboto", sans-serif;
-  /* color: #ed7164; */
   color: white;
 }
 
@@ -85,28 +84,24 @@ h4 {
   width: 100% !important;
 }
 
-.integration .screenshot {
-}
+.integration .screenshot {}
 
 .integration:first-of-type {
   background: #6897bb;
   padding-top: 20px;
   padding-bottom: 40px;
-  /* border-radius: 15px 15px 0 0; */
 }
 
 .integration:nth-of-type(2) {
   background: #ed7164;
   padding-top: 40px;
   padding-bottom: 40px;
-  /* border-radius: 0 0 15px 15px; */
 }
 
 .integration:nth-of-type(3) {
   background: #a0aab5;
   padding-top: 40px;
   padding-bottom: 40px;
-  /* border-radius: 0 0 15px 15px; */
 }
 
 /* .integration:nth-of-type(2) div.box {
@@ -119,7 +114,6 @@ h4 {
 .text-box h1 {
   font-size: 3rem;
   padding: 0 0 10px 0;
-  /* text-shadow: 0.5px 0.5px 1px #a0aab5; */
 }
 
 .text-box p {
@@ -166,9 +160,8 @@ h4 {
   background: #fff;
 }
 
-main > section {
+main>section {
   margin: 80px 0 100px 0;
-  /* width: 75%; */
   width: 90%;
   max-width: 1400px;
 }
@@ -296,8 +289,7 @@ img {
 
 @font-face {
   font-family: "Fira Code";
-  src: url(https://cdn.jsdelivr.net/npm/firacode@1.205.0/distr/woff2/FiraCode-Regular.woff2)
-    format("truetype");
+  src: url(https://cdn.jsdelivr.net/npm/firacode@1.205.0/distr/woff2/FiraCode-Regular.woff2) format("truetype");
 }
 
 .container {
@@ -342,7 +334,6 @@ nav#site-navigation {
 }
 
 nav#site-navigation ul {
-  /* display: inline-block; */
   font-family: "Roboto", sans-serif;
   font-size: 1.5rem;
 
@@ -383,7 +374,6 @@ header h1 {
 
 header p {
   color: #ed7164;
-  /* font-family: "Hind", "Open Sans", sans-serif; */
   font-size: 3rem;
   left: 50%;
   position: absolute;
@@ -463,7 +453,14 @@ header h1 img {
 #case-study p,
 #case-study pre,
 #case-study ul,
-#case-study ol {
+#case-study ol,
+#footnotes h3,
+#footnotes h4,
+#footnotes h5,
+#footnotes p,
+#footnotes pre,
+#footnotes ul,
+#footnotes ol {
   margin-bottom: 20px;
 }
 
@@ -477,12 +474,18 @@ header h1 img {
   margin: 75px auto 40px auto;
 }
 
-#case-study h2:first-of-type {
+#footnotes h2 {
+  margin: 75px auto 40px auto;
+}
+
+#case-study h2:first-of-type,
+#footnotes h2:first-of-type {
   margin-top: -15px;
 }
 
 #case-study h2,
-h3 {
+h3,
+#footnotes h2 {
   letter-spacing: 0.02rem;
 }
 
@@ -492,12 +495,8 @@ h3 {
   color: #ed7164;
 }
 
-/* #case-study ul,
-ol {
-  margin-left: 50px;
-} */
-
-#case-study p {
+#case-study p,
+#footnotes p {
   font-size: 1.2rem;
   line-height: 1.8rem;
 
@@ -524,10 +523,7 @@ hr {
   position: relative;
   margin-bottom: 50px;
   width: 100%;
-
   background-color: #fff;
-  /* border: 1px solid black;
-  border-radius: 10px; */
 }
 
 .softened {
@@ -583,7 +579,8 @@ hr {
   margin-bottom: 0;
 }
 
-#case-study li {
+#case-study li,
+#footnotes li {
   font-size: 1.1rem;
   line-height: 1.6rem;
   list-style: disc;
@@ -644,6 +641,16 @@ hr {
 
 /* ---------------------------------
 
+            footnotes
+
+------------------------------------ */
+
+#footnotes {
+  margin-left: 50px;
+}
+
+/* ---------------------------------
+
               commands
 
 ------------------------------------ */
@@ -652,19 +659,9 @@ hr {
   background-color: #eee;
   border-radius: 2px;
   color: #282828;
-  /*display: inline-block;*/
-  /*font-size: 1.2rem;*/
   font-weight: bold;
   margin-bottom: 20px;
   padding: 0.3rem;
-}
-
-#list-command code {
-  color: #ebdbb2;
-}
-
-#list-command .heading {
-  color: #98971a;
 }
 
 /* ---------------------------------
@@ -676,6 +673,10 @@ hr {
 h2#references {
   color: #ed7164;
   font-size: 1.7rem;
+}
+
+#footnotes h4 {
+  color: #a0aab5;
 }
 
 #footnotes {
@@ -710,13 +711,13 @@ h2#references {
 
 #our-team h1 {
   font-weight: 700;
-  padding-top: 100px;
-  margin-bottom: 30px;
+  padding-top: 60px;
+  padding-bottom: 60px;
   text-align: center;
   line-height: 4rem;
 }
 
-#our-team > p {
+#our-team>p {
   font-size: 1.2rem;
   line-height: 1.7rem;
   margin-top: 30px;
@@ -725,7 +726,7 @@ h2#references {
   width: 45%;
 }
 
-#our-team > ul {
+#our-team>ul {
   padding: 60px 0 80px;
   text-align: center;
 }
@@ -747,7 +748,7 @@ h2#references {
   text-decoration: none;
 }
 
-#our-team li > img {
+#our-team li>img {
   border-radius: 100%;
   margin: 0 auto 20px;
   width: 15vw;
@@ -877,7 +878,7 @@ small {
     overflow: scroll;
   }
 
-  nav#site-navigation > ul {
+  nav#site-navigation>ul {
     margin-top: 50px;
     padding-bottom: 50px;
   }
@@ -938,7 +939,7 @@ small {
     margin: 0;
   }
 
-  #our-team > p {
+  #our-team>p {
     width: 60%;
   }
 
@@ -958,6 +959,7 @@ small {
 }
 
 @media (max-width: 800px) {
+
   /* General */
   h1 {
     font-size: 3.5rem;
@@ -1045,7 +1047,7 @@ small {
 
   /* Our Team */
 
-  #our-team > p {
+  #our-team>p {
     width: 70%;
   }
 
@@ -1059,6 +1061,7 @@ small {
 }
 
 @media (max-width: 600px) {
+
   /* General */
   #case-study .img-wrapper img.big,
   img.medium {
@@ -1124,12 +1127,12 @@ small {
     padding-top: 60px;
   }
 
-  #our-team > p {
+  #our-team>p {
     font-size: 1rem;
     margin-top: 0;
   }
 
-  #our-team > ul {
+  #our-team>ul {
     margin-top: 0;
     padding: 0;
   }
@@ -1163,7 +1166,7 @@ small {
     padding: 3px;
   }
 
-  #our-team li > img {
+  #our-team li>img {
     width: 30vw;
   }
 }
@@ -1191,7 +1194,7 @@ small {
     padding: 2px;
   }
 
-  #our-team li > img {
+  #our-team li>img {
     width: 35vw;
   }
 
@@ -1249,7 +1252,7 @@ small {
     font-size: 1.1rem;
   }
 
-  nav#site-navigation > ul {
+  nav#site-navigation>ul {
     margin-top: 20px;
     padding-bottom: 25px;
   }
@@ -1270,7 +1273,7 @@ small {
     padding-bottom: 18px;
   }
 
-  #our-team > p {
+  #our-team>p {
     width: 57%;
   }
 }

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -672,7 +672,7 @@ hr {
 
 h2#references {
   color: #ed7164;
-  font-size: 1.7rem;
+  /* font-size: 1.7rem; */
 }
 
 #footnotes h4 {


### PR DESCRIPTION
### What
- Moved "References" section to the bottom, below "Our Team"
- Changed subheading font-color in References to a more neutral "RedPoint Gray"
- Made links to linkedIn, e-mail live
- Fixed numbering for sections (previously jumped from section 5 to 7 while skipping 6)

### Next Steps
- Add links to personal websites
- Re-Crop images so they are all exactly the same size (Will)
- Make spacing even in top-nav desktop view
- Add "Try RedPoint" and "Our Team" links to left-nav bar
- Various responsive design fixes for mobile views

### Screenshots
<img width="1672" alt="Screen Shot 2020-01-12 at 3 35 34 PM" src="https://user-images.githubusercontent.com/37784155/72226020-55246a00-355a-11ea-8992-3b9baba3677a.png">
<img width="1280" alt="Screen Shot 2020-01-12 at 2 51 24 PM" src="https://user-images.githubusercontent.com/37784155/72226022-59508780-355a-11ea-81b0-9c82d377306f.png">
